### PR TITLE
No more tensorflow and fixed requirements

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 from flask import Flask, render_template, request, redirect, abort
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from guesslang import Guess
 from os import environ
 from distutils.util import strtobool
 from threading import Thread
@@ -15,7 +14,7 @@ limiter = Limiter(
     app,
     key_func=get_remote_address
 )
-guess = Guess()
+
 
 from pastey import config, common, routes, functions
 

--- a/pastey/functions.py
+++ b/pastey/functions.py
@@ -1,4 +1,4 @@
-from __main__ import guess, app
+from __main__ import  app
 from . import config, common
 
 from os import path, remove
@@ -86,8 +86,7 @@ def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False)
         output_file = config.data_directory + "/" + unique_id
 
     # Attempt to guess programming language
-    guesses = guess.probabilities(content)
-    language = guesses[0][0] if guesses[0][1] > config.guess_threshold and guesses[0][0] not in config.ignore_guess else "Plaintext"
+    language = "Plaintext"
 
     # Check if encryption is necessary
     key = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-flask
+flask==1.1.2
 Flask-Limiter==1.4
-guesslang
-cryptography
+cryptography==3.4.7


### PR DESCRIPTION
I don't necessarily recommend merging this directly, apart from making sure that the requirements.txt has a ==version as this will install one version and not every version. This'll work now on raspberry pi 3 and 4. If i find a more lightweight language detection library i'll replace it here