### PR TITLE
Override format option for new pastes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/[Dd]ata/
+/pastey/__pycache__/

--- a/pastey/common.py
+++ b/pastey/common.py
@@ -1,5 +1,5 @@
 from . import config
-
+from __main__ import guess
 import ipaddress
 from os import path
 from pathlib import Path
@@ -61,6 +61,10 @@ def get_themes():
     for path in Path("./static/themes/").iterdir():
         themes.append(str(path).split('/')[-1].split('.')[0])
     return sorted(themes, key=str.casefold)
+
+# Get a list of all supported languages from guesslang
+def get_languages():
+    return guess.supported_languages
 
 # Get file path from unique id
 # This is a wrapper to check for files with the .expires extension

--- a/pastey/functions.py
+++ b/pastey/functions.py
@@ -79,7 +79,7 @@ def delete_paste(unique_id):
         remove(paste)
 
 # Create new paste
-def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False):
+def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False, language="AUTO"):
     unique_id = str(uuid.uuid4())
     output_file = config.data_directory + "/" + unique_id
 
@@ -89,8 +89,9 @@ def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False)
         output_file = config.data_directory + "/" + unique_id
 
     # Attempt to guess programming language
-    guesses = guess.probabilities(content)
-    language = guesses[0][0] if guesses[0][1] > config.guess_threshold and guesses[0][0] not in config.ignore_guess else "Plaintext"
+    if language == "AUTO":
+        guesses = guess.probabilities(content)
+        language = guesses[0][0] if guesses[0][1] > config.guess_threshold and guesses[0][0] not in config.ignore_guess else "Plaintext"
 
     # Check if encryption is necessary
     key = ""

--- a/pastey/routes.py
+++ b/pastey/routes.py
@@ -10,6 +10,9 @@ import json
 # Load themes
 loaded_themes = common.get_themes()
 
+# Load Languages
+supported_languages = common.get_languages()
+
 # Set rate limit
 # Workaround for @limiter annotations being parsed early
 config.rate_limit = environ["PASTEY_RATE_LIMIT"] if "PASTEY_RATE_LIMIT" in environ else config.rate_limit
@@ -40,6 +43,7 @@ def new():
     whitelisted = common.verify_whitelist(common.get_source_ip(request))
     return render_template("new.html",
         whitelisted=whitelisted,
+        languages=supported_languages,
         active_theme=common.set_theme(request),
         themes=loaded_themes)
 
@@ -118,9 +122,10 @@ def paste():
         single = True if 'single' in request.form else False
         encrypt = True if 'encrypt' in request.form else False
         expiration = int(request.form['expiration']) if 'expiration' in request.form else -1
+        language = request.form['language'] if 'language' in request.form else "AUTO"
 
         # Create paste
-        unique_id, key = functions.new_paste(title, content, source_ip, expires=expiration, single=single, encrypt=encrypt)
+        unique_id, key = functions.new_paste(title, content, source_ip, expires=expiration, single=single, encrypt=encrypt, language=language)
         if encrypt:
 
             # Return link if cli form option was set
@@ -176,9 +181,10 @@ def paste_json():
     single = paste['single'] if ('single' in paste and type(paste['single']) == bool) else False
     encrypt = paste['encrypt'] if ('encrypt' in paste and type(paste['encrypt']) == bool) else False
     expiration = paste['expiration'] if ('expiration' in paste and type(paste['expiration']) == int) else -1
+    language = paste['language'] if ('language' in paste and type(paste['language']) == str) else "AUTO"
 
     # Create paste
-    unique_id, key = functions.new_paste(title, content, source_ip, expires=expiration, single=single, encrypt=encrypt)
+    unique_id, key = functions.new_paste(title, content, source_ip, expires=expiration, single=single, encrypt=encrypt, language=language)
     if encrypt:
         return {
             "link": common.build_url(request, "/view/" + unique_id + "#" + quote(key))

--- a/templates/new.html
+++ b/templates/new.html
@@ -152,8 +152,8 @@
                     <select class="form-select form-select-md mb-3 pastey-select" id="language" name="language">
                       <option value="AUTO" selected>AUTO</option>
                       <option value="Plaintext">Plaintext</option>
-                      {% for lang in languages %}
-                      <option value="{{ lang }}">{{ lang }}</option>
+                      {% for language in languages %}
+                      <option value="{{ language }}">{{ language }}</option>
                       {% endfor %}
                     </select>
                   </div>

--- a/templates/new.html
+++ b/templates/new.html
@@ -136,7 +136,7 @@
                       </label>
                     </div>
                   </div>
-                  <div class="col-md-3">
+                  <div class="col-md-2">
                     <select class="form-select form-select-md mb-3 pastey-select" id="expiration" name="expiration">
                       <option value="-1" selected>Expires never</option>
                       <option value="1">Expires in 1 hour</option>
@@ -148,8 +148,17 @@
                       <option value="8760">Expires in 1 year</option>
                     </select>
                   </div>
+                  <div class="col-md-2">
+                    <select class="form-select form-select-md mb-3 pastey-select" id="language" name="language">
+                      <option value="AUTO" selected>AUTO</option>
+                      <option value="Plaintext">Plaintext</option>
+                      {% for lang in languages %}
+                      <option value="{{ lang }}">{{ lang }}</option>
+                      {% endfor %}
+                    </select>
+                  </div>
                   <div class="col-md-1"></div>
-                  <div class="col-md-4">
+                  <div class="col-md-3">
                       <button type="submit" class="btn btn-primary btn-block"><i class="fas fa-check"></i>&nbsp;&nbsp;&nbsp;Paste</button>
                   </div>
               </div>

--- a/templates/view.html
+++ b/templates/view.html
@@ -142,7 +142,6 @@
           <div class="row">
               <div class="col-md-12 mb-4">
                   {% if paste.language == "Plaintext" %}
-                  <!--<pre class="prettyprint linenums nocode" id="pastey-content">{{ paste.content }}</pre>-->
                   <pre class="prettyprint nocode" id="pastey-content">{{ paste.content }}</pre>
                   {% else %}
                   <pre class="prettyprint linenums" id="pastey-content">{{ paste.content }}</pre>

--- a/templates/view.html
+++ b/templates/view.html
@@ -135,13 +135,18 @@
     </div>
     <!-- Jumbotron -->
   </header>
-
+  
   <!--Main layout-->
   <main class="my-5">
       <div class="container">
           <div class="row">
               <div class="col-md-12 mb-4">
-                  <pre class="prettyprint linenums" id="pastey-content">{{ paste.content }}</pre>          
+                  {% if paste.language == "Plaintext" %}
+                  <!--<pre class="prettyprint linenums nocode" id="pastey-content">{{ paste.content }}</pre>-->
+                  <pre class="prettyprint nocode" id="pastey-content">{{ paste.content }}</pre>
+                  {% else %}
+                  <pre class="prettyprint linenums" id="pastey-content">{{ paste.content }}</pre>
+                  {% endif %}
               </div>    
           </div>
 


### PR DESCRIPTION
Made issue #15 initially for this and decided to try adding it in myself. This adds a new dropdown on the /new endpoint that lets the user select between AUTO (guess the language), Plaintext, and each language supported from guesslang.

I also changed how the view for plaintext pastes look, removing the numbered lines and code colouring. This change here was a personal preference for treating plaintext documents, though an alternative such as a toggle would be nice. This only affects plaintext formatted pastes and all others will be as they were before.

![image](https://user-images.githubusercontent.com/12175651/152588676-cb6dbf41-7dec-4f3e-aa00-d7b877d28b3d.png)

![image](https://user-images.githubusercontent.com/12175651/152588731-ad65995c-8b79-46d5-8c60-15fd00b4b487.png)

Fixes #15 