### PR TITLE
This is a patch to shorten the URLs generated by pastey

### DIFF
--- a/pastey/functions.py
+++ b/pastey/functions.py
@@ -85,7 +85,7 @@ def delete_paste(unique_id):
 # Create new paste
 def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False, language="AUTO"):
     # this calculates the number of digits of a base64 number needed to be unlikely to have collisions
-    id_len = int(math.ceil( 2*math.log(len(listdir(config.data_directory)))/math.log(256) ))+2
+    id_len = int(math.ceil( 2*math.log(len(listdir(config.data_directory))+1)/math.log(256) ))+2
     unique_id = secrets.token_urlsafe(id_len)
     output_file = config.data_directory + "/" + unique_id
 

--- a/pastey/functions.py
+++ b/pastey/functions.py
@@ -85,7 +85,7 @@ def delete_paste(unique_id):
 # Create new paste
 def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False, language="AUTO"):
     # this calculates the number of digits of a base64 number needed to be unlikely to have collisions
-    id_len = int(math.ceil( 2*math.log(len(listdir(config.data_directory))+2)/math.log(256) ))
+    id_len = int(math.ceil( 2*math.log(len(listdir(config.data_directory)))/math.log(256) ))+2
     unique_id = secrets.token_urlsafe(id_len)
     output_file = config.data_directory + "/" + unique_id
 

--- a/pastey/functions.py
+++ b/pastey/functions.py
@@ -85,8 +85,7 @@ def delete_paste(unique_id):
 # Create new paste
 def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False, language="AUTO"):
     # this calculates the number of digits of a base64 number needed to be unlikely to have collisions
-    id_len = int(math.ceil( 2*math.log(len(listdir(config.data_directory))+1)/math.log(256) ))+2
-    unique_id = secrets.token_urlsafe(id_len)
+    id_len = int(math.ceil( 3*math.log(len(listdir(config.data_directory))+1)/math.log(256) + 1.5 ))    unique_id = secrets.token_urlsafe(id_len)
     output_file = config.data_directory + "/" + unique_id
 
     # Check for existing paste id (unlikely)

--- a/pastey/functions.py
+++ b/pastey/functions.py
@@ -1,12 +1,13 @@
 from __main__ import guess, app
 from . import config, common
 
-from os import path, remove
+from os import path, remove, listdir
 from pathlib import Path
 from datetime import datetime, timedelta
 from cryptography.fernet import Fernet
 import time
-import uuid
+import secrets
+import math
 import json
 from os import environ
 
@@ -83,12 +84,14 @@ def delete_paste(unique_id):
 
 # Create new paste
 def new_paste(title, content, source_ip, expires=0, single=False, encrypt=False, language="AUTO"):
-    unique_id = str(uuid.uuid4())
+    # this calculates the number of digits of a base64 number needed to be unlikely to have collisions
+    id_len = int(math.ceil( 2*math.log(len(listdir(config.data_directory))+2)/math.log(256) ))
+    unique_id = secrets.token_urlsafe(id_len)
     output_file = config.data_directory + "/" + unique_id
 
     # Check for existing paste id (unlikely)
     while path.exists(output_file) or path.exists(output_file + ".expires"):
-        unique_id = str(uuid.uuid4())
+        unique_id = secrets.token_urlsafe(id_len)
         output_file = config.data_directory + "/" + unique_id
 
     # Attempt to guess programming language


### PR DESCRIPTION
https://github.com/Cesura/pastey/issues/13

This patch is based on a request to shorten URLs to make them easier to type.

The first URLs is 3 digits long. The second URL is 4 digits long until 17 pastes are made and then go up to 6 digits. As digits continue to increase, probability of collision remains less than 1.9e-6 forever.
